### PR TITLE
Reduce final bundle size by removing three from dependencies 

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,13 @@
   },
   "homepage": "https://github.com/luruke/magicshader#readme",
   "dependencies": {
-    "dat.gui": "^0.7.6",
-    "three": "^0.111.0"
+    "dat.gui": "^0.7.6"
   },
   "devDependencies": {
-    "parcel": "^1.12.4"
+    "parcel": "^1.12.4",
+    "three": "^0.111.0"
+  },
+  "peerDependencies": {
+    "three": ">= 0.111.0"
   }
 }


### PR DESCRIPTION
This optimization prevents to have two versions of `three` bundled by moving it from `dependencies` to `peerDependencies`. Then, when installing this package, it will use the `three` version already installed (as long as it matches the `>= 0.110.0`). If not, it will warn the user.

Before :  **432kb**
![magicshader-before](https://user-images.githubusercontent.com/13947885/73260126-9018d580-41c9-11ea-80f1-76df59afdec7.png)

After :  **290kb**
![magicshader-after](https://user-images.githubusercontent.com/13947885/73260539-601e0200-41ca-11ea-801d-9577235048a6.png)
